### PR TITLE
Generate subtitle .srt files in UTF8, closes debian bug #697976

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -7109,7 +7109,7 @@ sub download_subtitles {
 	# Open subs file
 	unlink($file);
 	open( my $fh, "> $file" );
-	binmode $fh;
+	binmode($fh, ":utf8");
 
 	# Download subs
 	$subs = main::request_url_retry($ua, $suburl, 2);


### PR DESCRIPTION
The conversion from .ttxt creates representations of characters like “₤” that M Player, for instance, displays incorrectly.
