### PR TITLE
Make script more portable with usr/bin/env

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # get_iplayer - Lists, Records and Streams BBC iPlayer TV and Radio programmes + other Programmes via 3rd-party plugins
 #


### PR DESCRIPTION
http://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html

This allows get_iplayer to "just work" with perlbrew installations

http://perlbrew.pl/

While remaining back-compat with any traditional / standard installation / setup.
