### PR TITLE
Do now allow lastbcast to be set to a future date/time. 

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -5451,7 +5451,7 @@ sub get_metadata {
 		# Flatten
 		$rdf =~ s|\n| |g;
 		# Get min/max bcast dates from rdf
-		my ( $first, $last, $first_string, $last_string ) = ( 9999999999, 0, 'Never', 'Never' );
+		my ( $now, $first, $last, $first_string, $last_string ) = ( time(), 9999999999, 0, 'Never', 'Never' );
 
 		# <po:(First|Repeat)Broadcast>
 		#  <po:schedule_date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2009-06-06</po:schedule_date>
@@ -5469,7 +5469,7 @@ sub get_metadata {
 				$first = $epoch;
 				$first_string = $timestring;
 			}
-			if ( $epoch > $last ) {
+			if ( $now > $epoch && $epoch > $last ) {
 				$last = $epoch;
 				$last_string = $timestring;
 			}


### PR DESCRIPTION
For some radio programmes the RDF contains broadcast dates in the future. An example might be "My First Planet". 
This fix prevents future broadcast dates being assigned to lastbcast.

Example before fix :- 
![image](https://f.cloud.github.com/assets/4943524/761175/196e120a-e7c7-11e2-9567-943913eb041c.png)

Example after fix :- 
![image](https://f.cloud.github.com/assets/4943524/761176/35ebadde-e7c7-11e2-8ce8-a356e90f5ce8.png)
