### PR TITLE
Fix typo in the regex table in create_xml().

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -2374,7 +2374,7 @@ sub create_xml {
 			'J-L' => '[jkl]',
 			'M-N' => '[mn]',
 			'O-P' => '[op]',
-			'Q-R' => '[qt]',
+			'Q-R' => '[qr]',
 			'S-T' => '[st]',
 			'U-V' => '[uv]',
 			'W-Z' => '[wxyz]',


### PR DESCRIPTION
should be self-evident :-)
