### PR TITLE
Add BBC Sport as a masterbrand to fetch

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -7042,6 +7042,7 @@ sub channels {
 		'bbc_two'			=> 'BBC Two',
 		'bbc_three'			=> 'BBC Three',
 		'bbc_four'			=> 'BBC Four',
+		'bbc_sport'                     => 'BBC Sport',
 		'cbbc'				=> 'CBBC',
 		'cbeebies'			=> 'CBeebies',
 		'bbc_news24'		=> 'BBC News',


### PR DESCRIPTION
BBC sport shows (such as formula 1) aren't being downloaded - this adds the bbc sport as a master brand to fetch.
