### PR TITLE
Suppress spurious errors in PVR log.

### DIFF
--- a/get_iplayer.cgi
+++ b/get_iplayer.cgi
@@ -1839,7 +1839,9 @@ sub interpret_return_code {
 	my $rtn = shift;
 	# Interpret return code	and force return code 2 upon error      
 	my $return = $rtn >> 8;
-	if ( $rtn == -1 ) {
+	if ( $rtn == -1 && $IGNOREEXIT ) {
+		$return = 0;
+	} elsif ( $rtn == -1 ) {
 		print $se "ERROR: Command failed to execute: $!\n";
 		$return = 2 if ! $return;
 	} elsif ( $rtn & 128 ) {


### PR DESCRIPTION
When running in PVR mode get_iplayer.cgi sets `$SIG{CHLD} = 'IGNORE'` at line 311.
This means that `$?` returns -1 for all subsequent subprocess/pipe invocations, which in turn causes get_iplayer.cgi to emit spurious errors:

```
ERROR: Command failed to execute: No child processes
INFO: Command exit code 16777215
```

This patch suppresses those messages.
