### PR TITLE
Make Windows get_iplayer.cmd callable from any directory

### DIFF
--- a/windows/get_iplayer/get_iplayer.cmd
+++ b/windows/get_iplayer/get_iplayer.cmd
@@ -1,2 +1,9 @@
 @echo off
-perl.exe get_iplayer.pl %*
+setlocal
+
+set PERLEXE=%~dp0perl.exe
+
+:: if local perl.exe doesn't exist assume it can be found on PATH
+if not exist "%PERLEXE%" set PERLEXE=perl.exe
+
+"%PERLEXE%" "%~dp0get_iplayer.pl" %*


### PR DESCRIPTION
Make paths to get_iplayer.pl and perl.exe absolute so get_iplayer.cmd can be called from any directory. 
Prefer local perl.exe, otherwise assume it exists on PATH.
