### PR TITLE
Web PVR: Open description in new tab

### DIFF
--- a/get_iplayer.cgi
+++ b/get_iplayer.cgi
@@ -3060,7 +3060,7 @@ sub search_progs {
 			} elsif ( /^desc$/ ) {
 				my $text = $prog{$pid}->{$_};
 				$text = substr($text, 0, 256).'...[more]' if length( $text ) > 256;
-				push @row, td( {-class=>$search_class}, label( { -class=>$search_class, -title=>"Click for full info", -onClick=>"BackupFormVars(form); form.NEXTPAGE.value='show_info'; form.INFO.value='".encode_entities("$prog{$pid}->{type}|$pid")."'; form.submit(); RestoreFormVars(form);" }, $text ) );
+				push @row, td( {-class=>$search_class}, label( { -class=>$search_class, -title=>"Click for full info", -onClick=>"BackupFormVars(form); form.NEXTPAGE.value='show_info'; form.INFO.value='".encode_entities("$prog{$pid}->{type}|$pid")."'; form.target='_blank'; form.submit(); RestoreFormVars(form); form.target='';" }, $text ) );
 			# Name / Series link
 			} elsif ( /^name$/ ) {
 				push @row, td( {-class=>$search_class}, label( { -class=>$search_class, -id=>'underline', -title=>"Click to list '$prog{$pid}->{$_}'",


### PR DESCRIPTION
In the Web PVR, when the description for a search result is clicked, open the info page in a new tab. This is particularly helpful for users of at least some screen readers because otherwise, the user's position in the original page is lost, which is pretty painful when dealing with a long list of search results. I wonder whether this is even preferable for some non-screen reader users because they can just switch back to the original tab to look at other results while info pages are loading, etc.
