### PR TITLE
Show how to install dependencies on Linux (apt-based)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@
 
 	`export IPLAYER_OUTDIR="/path/to/my/output/dir"`
 
+* Install dependencies (the first is required, the others allow you to download more formats).  On Ubuntu this can be done as follows:
+
+	`sudo apt-get install libxml-simple-perl ffmpeg rtmpdump`
+
 * The first time you run the script it will create a settings directory (`$HOME/.get_iplayer` [Linux/Unix/OSX] `%USERPROFILE%\.get_iplayer` [Windows]) and download plugins.  It will then access the BBC website and create an index of all TV programmes currently on iPlayer.
 
 ## Installation (Windows)


### PR DESCRIPTION
I wasted a lot of time trying to perform my first download. For a while I thought get-iplayer just didn't work any more!

It turns out all I needed was the dependencies!

This pull request simply makes the dependencies (for Debian/Ubuntu/Mint) clear in the README.

----

I think also the error messages could be improved, to explain that I need to install ffmpeg or rtmpdump.  However, I have not done that in this pull request.

This is the output I was getting before I installed dependencies:

```
INFO: 1 Matching Programmes
INFO: Checking existence of default version
INFO: No specified modes () available for this programme with version 'default'
INFO: Try using --modes=flashhd,flashhigh,flashlow,flashstd,flashvhigh,hlshd,hlshigh,hlslow,hlsstd,hlsvhigh,subtitles
INFO: Checking existence of original version
INFO: No specified modes () available for this programme with version 'original'
INFO: Try using --modes=flashhd,flashhigh,flashlow,flashstd,flashvhigh,hlshd,hlshigh,hlslow,hlsstd,hlsvhigh,subtitles
INFO: Checking existence of audiodescribed version
INFO: No specified modes () available for this programme with version 'audiodescribed'
INFO: Try using --modes=flashhigh,hlshigh
ERROR: Failed to record .....
```

There is no mention in that log that I am missing dependencies. When I googled for the error `get_iplayer "No specified modes"` none of the links helped.

It is true that when I did run with the recommended `--modes=...` argument then the output did indicate that I was missing deps:

```
WARNING: Required rtmpdump does not exist - cannot download Flash audio/video
WARNING: Required ffmpeg does not exist - cannot download HLS audio/video
```

but I foolishly ignored these.  I was simply confused that I hadn't seen any complaint about deps to begin with.

When I did install the deps, get_iplayer downloaded videos fine, without me having to provide any extra `--modes`.