### PR TITLE
parse_rdf_series: handle multpile series gracefully

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -6790,10 +6790,11 @@ sub parse_rdf_series {
 		return '';
 	}
 	my @pids = ();
-	my $spid = extract_pid( $rdf->{'po:Series'}->{'rdf:about'} );
-	main::logger "INFO:    Series: '".$rdf->{'po:Series'}->{'dc:title'}."' ($spid)\n";
+	my ($series) = ensure_array($rdf->{'po:Series'});
+	my $spid = extract_pid( $series->{'rdf:about'} );
+	main::logger "INFO:    Series: '".$series->{'dc:title'}."' ($spid)\n";
 	main::logger "INFO:      From Brand PID '".$rdf->{'po:Brand'}->{'rdf:about'}."'\n" if $opt->{debug};
-	for my $episode_element (ensure_array($rdf->{'po:Series'}->{'po:episode'})) {
+	for my $episode_element (ensure_array($series->{'po:episode'})) {
 		my $pid = extract_pid( $episode_element->{'po:Episode'}->{'rdf:about'} );
 		main::logger "INFO:      Episode '".$episode_element->{'po:Episode'}->{'dc:title'}."' ($pid)\n";
 		push @pids, $pid;


### PR DESCRIPTION
Some rdf series, like the following, apparently have two series entries.

$ xmllint --format http://www.bbc.co.uk/programmes/b06132hb.rdf
...
  <po:Series rdf:about="/programmes/b06132hb#programme">
    <po:pid>b06132hb</po:pid>
    <dc:title>Series 2</dc:title>
...
  <po:Series rdf:about="/programmes/b04ww52q#programme">
    <po:series rdf:resource="/programmes/b06132hb#programme"/>
  </po:Series>
</rdf:RDF>

With such a series, get_iplayer bails out with an error.

$ get_iplayer --info --pid=b06132hb
...
INFO: Series pid detected
Not a HASH reference at /home/at/bin/get_iplayer line 6793.

With this change, get_iplayer will now use the first series entry.