### PR TITLE
suggested update update get_iplayer to fix CRLF problem

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -10495,6 +10495,7 @@ sub get {
 		$bin->{ffmpeg},
 		@{$binopts->{ffmpeg}},
 		@globals,
+		'-headers', 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/601.2.7 (KHTML, like Gecko) Version/9.0.1 Safari/601.2.7\r\n',
 		'-i', $url,
 	);
 	if ( ! $opt->{nowrite} ) {


### PR DESCRIPTION
 with custom user agent headers when recording iplayer from hls using ffmpeg

added an additional user agent header function/variable to command to send to ffmpeg while recording iplayer with hls in script function @cmd at line 10494, under @globals and before ffmpeg -i variable. Of course, the header I used can be changed to use a header from the existing userr agent header-function at line 1576. 

If this is included in a future update to get_iplayer could I be added as a contributor to this repository?

With regards, dave, netherlands/uk