### PR TITLE
Adding IPv6 Support

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -63,6 +63,7 @@ use HTTP::Cookies;
 use HTTP::Headers;
 use IO::Seekable;
 use IO::Socket;
+use Net::INET6Glue::INET_is_INET6;
 use LWP::ConnCache;
 use LWP::UserAgent;
 use POSIX qw(mkfifo);

--- a/get_iplayer.cgi
+++ b/get_iplayer.cgi
@@ -303,6 +303,7 @@ my @nosearch_params = qw/ /;
 ### Perl CGI Web Server ###
 use Socket;
 use IO::Socket;
+use Net::INET6Glue::INET_is_INET6;
 my $IGNOREEXIT = 0;
 # If the port number is specified then run embedded web server
 if ( $opt_cmdline->{port} > 0 ) {


### PR DESCRIPTION
This PR adds IPv6 support to both the `get_iplayer` script, and the `get_iplayer` web frontend.

It does not change the default behavior (IPv4), simply allows you to bind to IPv6 if you choose to.

The BBC themselves seems to have no (or very limited) public facing IPv6 support currently (this will obviously have to change in future). However the main reason I've patched `get_iplayer` is so it can work with proxies which do speak IPv6.

A more robust patch would change all the `IO::Socket:INET` sockets to be `IO::Socket:IP` sockets, but `INET6Glue` hot-patchs this for us in the meantime. A future patch would also handle listening on both IPv4 and IPv6 simultaneously.


Confirms listening on IPv6 when requested:

    ~$ ./get_iplayer.cgi --port=8080 --listen=:: &
    ~$ lsof -i :8080
    COMMAND   PID    USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
    perl    12881 hcooper    3u  IPv6  96970      0t0  TCP *:http-alt (LISTEN)


Confirms the default is IPv4 still:

    ~$ ./get_iplayer.cgi --port=8080 &
    ~$ lsof -i :8080
    COMMAND   PID    USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
    perl    12911 hcooper    3u  IPv4  97175      0t0  TCP *:http-alt (LISTEN)

Shows a refresh fetching over IPv6:

    ~$ ./get_iplayer --refresh &
    ~$ lsof -i -n
    perl      13237       hcooper    3u  IPv6  97807      0t0  TCP [2602:xx:xxxx:xxxx:xxxx:xxxx:xxxx:xx]:40541->[2a01:yyyy::yyyy:yyyy:yyyy:yyyy]:http (ESTABLISHED)
