### PR TITLE
Re-include "hlsvhigh" into the default tvmodes...

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -8165,7 +8165,7 @@ sub modelist {
 		$mlist = main::expand_list($mlist, 'tvdefault', 'tvbest');
 		$mlist = main::expand_list($mlist, 'tvbest', 'hvfhd,hlshd,tvbetter');
 		$mlist = main::expand_list($mlist, 'tvbetter', 'hvfsd,tvvgood');
-		$mlist = main::expand_list($mlist, 'tvvgood', 'hvfvhigh,hlsvigh,tvgood');
+		$mlist = main::expand_list($mlist, 'tvvgood', 'hvfvhigh,hlsvhigh,tvgood');
 		$mlist = main::expand_list($mlist, 'tvgood', 'hvfhigh,hlshigh,tvworse');
 		$mlist = main::expand_list($mlist, 'tvworse', 'hvfstd,hlsstd,tvworst');
 		$mlist = main::expand_list($mlist, 'tvworst', 'hvflow,hlslow');


### PR DESCRIPTION
 Due to a typo, the "hlsvhigh" tvmode was excluded from the "default" modes for Video-On-Demand. 
This bug affects mostly video clips which, as a rule of thumb, aren't available in either "(hls|flash)hd" 
nor "hvf" tvmodes; not specifying a mode or using "--modes=best" results in the inferior quality "hlshigh"
tvmode to be fetched, when in fact "hlsvhigh" is also available.... 

 For the released version (2.96) of get_iplayer, the user is advised to issue either "--modes=hlsbest" 
or the (deprecated) "--modes=flashbest" to circumvent this bug and obtain the 832x468p@25fps encode...