### PR TITLE
Updated SWF player URL

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -7222,7 +7222,7 @@ sub get_stream_data_cdn {
 		# Common attributes
 		# swfurl = Default iPlayer swf version
 		my $conn = {
-			swfurl		=> $opt->{swfurl} || "http://emp.bbci.co.uk/emp/SMPf/1.16.6/StandardMediaPlayerChromelessFlash.swf",
+			swfurl		=> $opt->{swfurl} || "http://emp.bbci.co.uk/emp/SMPf/1.17.0/StandardMediaPlayerChromelessFlash.swf",
 			ext		=> $ext,
 			streamer	=> $streamer,
 			bitrate		=> $mattribs->{bitrate},


### PR DESCRIPTION
 Probably not that important after the deprecation of "flash" modes, but people (and I) still use them for their own reasons, so keeping this updated (until RTMP support is gone in 2.98) actually doesn't hurt...