### PR TITLE
ensure_array(undef) should return an empty array

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -6562,7 +6562,7 @@ sub get_pids_recursive {
 
 sub ensure_array {
 	my ($in) = @_;
-	return ref $in eq 'ARRAY' ? @$in : $in;
+	return defined $in ? ref $in eq 'ARRAY' ? @$in : $in : ();
 }
 
 # Gets the episode data from a given episode pid


### PR DESCRIPTION
Previously, `ensure_array(undef)` would return `undef` (not an array). Assigning this scalar return value to an array variable converts it to `[undef]` (an array with 1 element whose value is undef). Subsequently testing this array for emptiness unexpectedly fails.

For me, this manifested as harmless but annoying warnings/errors in every PVR run with recursive brand pid, making automated reporting unnecessarily noisy. Firstly:
```
INFO: Brand pid detected
INFO:  Brand: 'Class' (p048h1bz)
INFO:    Series: 'Series 1' (p048h1kr)
INFO:      Episode 'For Tonight We Might Die' (p048h1s0)
INFO:      Episode 'The Coach with the Dragon Tattoo' (p04c1bs4)
INFO:      Episode 'Nightvisiting' (p04d06nr)
INFO:      Episode 'Co-Owner of a Lonely Heart' (p04dr5sg)
INFO:      Episode 'Brave-ish Heart' (p04f22jc)
INFO:      Episode 'Detained' (p04f1ytz)
INFO:      Episode 'The Metaphysical Engine, or What Quill Did' (p04fyn6b)
INFO:      Episode 'The Lost' (p04gbbgm)
INFO:    Series: <None>
WARNING: rdf URL contained no data
WARNING: Episode PID rdf URL contained no RDF data.
```
Secondly (after the successful processing of pids in series 1):
```
INFO: Trying pid:  using type: tv
INFO: Trying to stream pid using type tv
INFO: pid not found in tv cache
Matches:

INFO: 1 Matching Programmes
ERROR: No PID for index  (try using --type option ?)
WARNING: PVR Run: Class: 1 download failure(s)
```

The PVR in question:
```
type tv
pid p048h1bz
pidrecursive 1
pidrecursivenoclips 1
```

I've tested this fix using `get_iplayer --type tv --pid p048h1bz --pidrecursive --pidrecursivenoclips --test` (with no errors or warnings or suspicious `Series: <None>` or messages with empty pid/index) on the following platforms:
* a FreeBSD 10.3-STABLE jail on a FreeNAS 9.10 host running all the latest get_iplayer dependencies (`pkg install get_iplayer && pkg update`) and develop branch of get_iplayer installed in place of the outdated FreeBSD-packaged version.
* Windows 8.1 x64 with get_iplayer freshly installed using the chocolatey package (which downloaded and installed 2.97-windows.0 from the official github release).