### PR TITLE
Fix schedule refresh with limit at end of year

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -6409,7 +6409,7 @@ use IO::Seekable;
 use IO::Socket;
 use LWP::ConnCache;
 use LWP::UserAgent;
-use POSIX qw(mkfifo strftime);
+use POSIX qw(ceil mkfifo strftime);
 use strict;
 use Time::Local;
 use URI;
@@ -6787,12 +6787,12 @@ sub get_links_schedule {
 		my $limit_days = $opt->{"refreshlimit".${prog_type}} || $opt->{"refreshlimit"};
 		$limit_days = 0 if $limit_days < 0;
 		$limit_days = 30 if $limit_days > 30;
-		$limit = $now - ($limit_days * 86400) if $limit_days;
+		$limit = $now - (ceil($limit_days / 7) * 7 * 86400) if $limit_days;
 		if ( $limit ) {
 			my $limit_time = $limit;
 			my $limit_year = (gmtime($limit_time))[5];
 			my $limit_week = strftime( "%W", gmtime($limit_time) );
-			while ( $limit_week != $this_week ) {
+			while ( $limit_time < $then ) {
 				push @schedule_dates, sprintf("%04d/w%02d", $limit_year+1900, $limit_week+1);
 				$limit_time += $one_week;
 				$limit_year = (gmtime($limit_time))[5];


### PR DESCRIPTION
When a refresh limit is set and not divisible by 7 days, refreshing programme schedules at the end of the year can incorrectly try to download schedules for all weeks in at least the next year. I detected this problem today because my refresh limit is set to 30 days and get_iplayer attempted to download schedules for all weeks of 2017. This seems to be because today is in "week 52" but starting from 30 days ago and incrementing 7 days at a time means that the Sunday that is in "this week" falls into what Perl calls "week 0" of 2017.

The earliest date I've found in my non-scientific search where this behaviour becomes a significant problem is December 31st 2018, which is a Monday and "week 53". In this case, for users with `$limit_days + 1` divisible by 7 get_iplayer will attempt to download schedules for all weeks to the end of 2024. More worrying, for users with neither `$limit_days` nor `$limit_days + 1` divisible by 7 (73% of the possible non-zero refresh limits), get_iplayer will go into what looks like an infinite loop generating the list of schedule weeks it wants to download. I'm sure it could be proven this will be infinite with maths, testing with limits of 1-5 days reached a year of 20000+ without matching the loop escape criteria.

I've tested this patch today using `get_iplayer --refresh --refresh-limit 30` (confirming that `WARNING: Failed to download programme schedule ...` messages for weeks in 2017 no longer appear) on the following platforms:
- a FreeBSD 10.3-STABLE jail on a FreeNAS 9.10 host running all the latest get_iplayer dependencies (pkg install get_iplayer && pkg update) and develop branch of get_iplayer installed in place of the outdated FreeBSD-packaged version.
- Windows 8.1 x64 with get_iplayer installed using the chocolatey package (2.97-windows.0).