### PR TITLE
Added advanced option to allow filenames to be limited in length

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -171,6 +171,7 @@ my $opt_format = {
 	# Output
 	command		=> [ 1, "c|command=s", 'Output', '--command, -c <command>', "Run user command after successful recording of programme using substitution paramaters such as <dir>, <fileprefix>, <filename>, etc."],
 	fileprefix	=> [ 1, "file-prefix|fileprefix=s", 'Output', '--file-prefix <format>', "The filename prefix (excluding dir and extension) using formatting fields. e.g. '<name>-<episode>-<pid>'"],
+	limitprefixlength => [ 1, "limitprefixlength=n", "Output", '--limitprefixlength <length>', "The maximum length for a file prefix.  Defaults to 240 to allow space within standard 256 limit."],
 	metadata	=> [ 1, "metadata=s", 'Output', '--metadata <format>', "Create metadata info file after recording. Valid formats are: 'generic'"],
 	output		=> [ 2, "output|o=s", 'Output', '--output, -o <dir>', "Recording output directory"],
 	subdir		=> [ 1, "subdirs|subdir|s!", 'Output', '--subdir, -s', "Save recorded files into subdirectory. Default: same name as programme."],
@@ -4010,7 +4011,11 @@ sub generate_filenames {
 	$prog->{fileprefix} = main::encode_fs($prog->{fileprefix});
 
 	# Truncate filename to 240 chars (allows for extra stuff to keep it under system 256 limit)
-	$prog->{fileprefix} = substr( $prog->{fileprefix}, 0, 240 );
+	# limitprefixlength allows this to be shortened
+	unless ( $opt->{limitprefixlength} ) {
+		$opt->{limitprefixlength} = 240;
+	}
+	$prog->{fileprefix} = substr( $prog->{fileprefix}, 0, $opt->{limitprefixlength} );
 
 	main::logger "'$prog->{fileprefix}'\n" if $opt->{debug};
 


### PR DESCRIPTION
I use ecryptfs on my home directory and this is where get_iplayer is storing its data.

Unfortunately, ecryptfs is encrypting the filenames and this limits filename lengths to approximately 140 characters.  This pull request allows the existing 240 character file prefix length limit to be reduced using an advanced option.

I think this is a very limited risk change, but I've only been able to test it on Linux.