### PR TITLE
Identification of ffmpeg nightly builds

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -787,7 +787,7 @@ sub init_search {
 	my $ffout = `$ffcmd`;
 	if ( $ffout =~ /ffmpeg version (\S+)/i ) {
 		$ffvs = $1;
-		if ( $ffvs =~ /^(\d+\.\d+)/i ) {
+		if ( $ffvs =~ /^n*(\d+\.\d+)/i ) {
 			$ffvn = $1;
 			if ( $ffvn >= 3.0 ) {
 				$opt->{ffmpeg30} = 1;


### PR DESCRIPTION
Some users will/might be running nightly builds of ffmpeg, identified with a version number nx.y.z. This change will help the code to identify those builds correctly and make the detection more robust.
