### PR TITLE
Adds thumbsrc option to prefer episode thumbnails

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -179,6 +179,7 @@ my $opt_format = {
 	thumbext	=> [ 1, "thumbext|thumb-ext=s", 'Output', '--thumb-ext <ext>', "Thumbnail filename extension to use"],
 	thumbsizecache	=> [ 1, "thumbsizecache=n", 'Deprecated', '--thumbsizecache <index|width>', "Default thumbnail size/index to use when building cache. index: 1-11 or width: 86,150,178,512,528,640,832,1024,1280,1600,1920"],
 	thumbsize	=> [ 1, "thumbsize|thumbsizemeta=n", 'Output', '--thumbsize <index|width>', "Default thumbnail size/index to use for the current recording and metadata. index: 1-11 or width: 86,150,178,512,528,640,832,1024,1280,1600,1920"],
+	thumbsrc	=>	[ 1, "thumbsrc|thumb-src=s", 'Output', '--thumb-src <src>', "Thumbnail source preference.  Valid sources are: 'episode', 'default'.  Defaults to series/brand thumbnail if available."],
 	whitespace	=> [ 1, "whitespace|ws|w!", 'Output', '--whitespace, -w', "Keep whitespace in file and directory names.  Default behaviour is to replace whitespace with underscores."],
 
 	# Config
@@ -4688,13 +4689,16 @@ sub get_metadata {
 					$meddesc = $doc->{medium_synopsis};
 					$summary = $doc->{short_synopsis};
 					$channel = $doc->{ownership}->{service}->{title};
+					my $thumbsrc = $opt->{thumbsrc} || 'default';
 					my $image_pid = $doc->{image}->{pid};
 					my $series_image_pid = $doc->{parent}->{programme}->{image}->{pid};
 					my $brand_image_pid = $doc->{parent}->{programme}->{parent}->{programme}->{image}->{pid};
-					if ( $series_image_pid ) {
-						$image_pid = $series_image_pid;
-					} elsif ( $brand_image_pid ) {
-						$image_pid = $brand_image_pid;
+					if ( $thumbsrc ne 'episode' ) {
+						if ( $series_image_pid ) {
+							$image_pid = $series_image_pid;
+						} elsif ( $brand_image_pid ) {
+							$image_pid = $brand_image_pid;
+						}
 					}
 					my $thumbsize = $opt->{thumbsize} || $opt->{thumbsizecache} || 150;
 					my $recipe = Programme::bbciplayer->thumb_url_recipes->{ $thumbsize };
@@ -7140,15 +7144,18 @@ sub get_links_schedule_page {
 		# thumbnail options
 		# http://ichef.bbci.co.uk/programmeimages/p01m1x5p/b04l8sml_640_360.jpg
 		# http://ichef.bbci.co.uk/images/ic/640x360/p01m1x5p.jpg
-		# Default to 150px width thumbnail;
+		# Default to 150px width series/brand thumbnail;
 		my $thumbsize = $opt->{thumbsizecache} || 150;
+		my $thumbsrc = $opt->{thumbsrc} || 'default';
 		my $image_pid = $1 if $entry =~ m{<image><pid>(.*?)</pid>}s;
 		my $series_image_pid = $1 if $entry =~ m{<programme\s+type="series">.*?<image><pid>(.*?)</pid>};
 		my $brand_image_pid = $1 if $entry =~ m{<programme\s+type="brand">.*?<image><pid>(.*?)</pid>};
-		if ( $series_image_pid ) {
-			$image_pid = $series_image_pid;
-		} elsif ( $brand_image_pid ) {
-			$image_pid = $brand_image_pid;
+		if ( $thumbsrc ne 'episode' ) {
+			if ( $series_image_pid ) {
+				$image_pid = $series_image_pid;
+			} elsif ( $brand_image_pid ) {
+				$image_pid = $brand_image_pid;
+			}
 		}
 		my $suffix = Programme::bbciplayer->thumb_url_suffixes->{ $thumbsize };
 		$suffix = Programme::bbciplayer->thumb_url_suffixes->{ 150 } unless $suffix;


### PR DESCRIPTION
Addresses https://squarepenguin.co.uk/forums/thread-1276.html with --thumbsrc=episode, otherwise defaults to the current behavior.

Argument for including: Radio episodes often have useful and selected thumbnails that are addressed in the program description, see e.g. http://www.bbc.co.uk/programmes/b006qt55/episodes/player or http://www.bbc.co.uk/programmes/b0738jc2/episodes/player. All episodes of the latter series for example, such as http://www.bbc.co.uk/programmes/p058gh24, describe the image, e.g. "Image: Cadets during a National Conference rally at Lal Chowk, Srinagar 1944 Credit: India Picture". Having hundreds of episodes with the same unrelated series thumbnail is not very helpful.

Tested on Windows only, using Strawberry Perl.