### PR TITLE
Fix download URI catcher

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -522,7 +522,7 @@ if ( ! $opt->{pid} && ! $opt->{fields} ) {
 	if ( $search_args[0] =~ m{^(\w+:)?https?://} ) {
 		$opt->{pid} = $search_args[0];
 	}
-	elsif ( $search_args[0] =~ m{^bbc-ipd:download/(\w+)/\w+/(\w+)/} ) {
+	elsif ( $search_args[0] =~ m{^bbc-ipd:/*download/(\w+)/\w+/(\w+)/} ) {
 		$opt->{pid} = $1;
 		$opt->{modes} ||= "best" if $2 eq "hd";
 	}


### PR DESCRIPTION
Not sure why, but these URIs have started coming through as `bbc-ipd:///download/…` rather than `bbc-ipd:download/…`.