### PR TITLE
Replace directory separators in subdir names

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -3727,7 +3727,7 @@ sub generate_filenames {
 	# Don't create subdir if we are only testing recordings
 	# Create a subdir for programme sorting option
 	elsif ( $opt->{subdir} ) {
-		my $subdir = $prog->substitute( $opt->{subdirformat} || '<longname>', 1 );
+		my $subdir = $prog->substitute( $opt->{subdirformat} || '<longname>' );
 		$prog->{dir} = File::Spec->catdir($prog->{dir}, $subdir);
 		$prog->{dir} = main::encode_fs($prog->{dir});
 		main::logger("INFO: Creating subdirectory $prog->{dir} for programme\n") if $opt->{verbose};


### PR DESCRIPTION
Replace slashes with underscores in subdir names. This avoids extra
subdirectories being created when programme name contains slashes.

Example: http://www.bbc.co.uk/programmes/b09dcjgh