### PR TITLE
Make HQ audio for "hls" modes opt-in with --hls-hq-audio option

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -85,9 +85,10 @@ my $opt_format = {
 	includehttps		=> [ 1, "includehttps|include-https!", 'Recording', '--include-https', "Allow HTTPS playlist/manifest/segment URLs for media streams."],
 	includesupplier	=> [ 1, "includesupplier|include-supplier=s", 'Recording', '--include-supplier <supplier>,<supplier>,...', "Comma-separated list of media stream suppliers to use if not included by default.  Possible values: akamai,limelight,bidi"],
 	hash		=> [ 1, "hash!", 'Recording', '--hash', "Show recording progress as hashes"],
+	hlshqaudio	=> [ 1, "hlshqaudio|hls-hq-audio!", 'Recording', '--hls-hq-audio', "Attempt to download higher-quality audio for 'hls' modes (TV only). Output file may require editing to sync audio and video."],
 	logprogress		=> [ 1, "log-progress|logprogress!", 'Recording', '--log-progress', "Force HLS/DASH download progress display to be captured when screen output is redirected to file.  Progress display is normally omitted unless writing to terminal."],
 	modes		=> [ 0, "modes=s", 'Recording', '--modes <mode>,<mode>,...', "Recording modes.  See --tvmode and --radiomode (with --long-help) for available modes and defaults.  Shortcuts: tvworst,tvworse,tvgood,tvvgood,tvbetter,tvbest,radioworst,radioworse,radiogood,radiovgood,radiobetter,radiobest (default=default for programme type)."],
-	nohqaudio	=> [ 1, "nohqaudio|no-hq-audio!", 'Recording', '--no-hq-audio', "Do not attempt to use higher-quality audio with HLS TV streams ('hvf' and 'hls' modes)."],
+	nohqaudio	=> [ 1, "nohqaudio|no-hq-audio!", 'Ignored', '--no-hq-audio', "Do not attempt to use higher-quality audio with HLS TV streams ('hvf' and 'hls' modes)."],
 	noproxy	=> [ 1, "noproxy|no-proxy!", 'Recording', '--no-proxy', "Ignore --proxy setting in preferences and/or http_proxy environment variable."],
 	overwrite	=> [ 1, "overwrite|over-write!", 'Recording', '--overwrite', "Overwrite recordings if they already exist"],
 	partialproxy	=> [ 1, "partial-proxy!", 'Recording', '--partial-proxy', "Only uses web proxy where absolutely required (try this extra option if your proxy fails)."],
@@ -5432,10 +5433,8 @@ sub get_stream_data {
 							next;
 						}
 						my $prefix = $iptv_conn->{supplier} =~ /hls_open/ ? "hls" : "hvf";
-						unless ( $opt->{nohqaudio} ) {
-							# for 320k audio
-							$iptv_conn->{href} =~ s!([^/]+)\.ism(?:\.hlsv2\.ism)?/[^/]+\.m3u8!$1.ism/$1.m3u8!;
-						}
+						# for 320k audio
+						$iptv_conn->{href} =~ s!([^/]+)\.ism(?:\.hlsv2\.ism)?/[^/]+\.m3u8!$1.ism/$1.m3u8!;
 						my ( $min_bitrate, $max_bitrate );
 						if ( $prefix eq "hvf" ) {
 							$min_bitrate = 1500;
@@ -5491,10 +5490,8 @@ sub get_stream_data {
 							$prefix = "hlsaac";
 						}
 					}
-					unless ( $prog->{type} eq "tv" && $opt->{nohqaudio} ) {
-						# for 320k audio (tv/radio) and 96k audio (radio)
-						$mobile_conn->{href} =~ s!([^/]+)\.ism(?:\.hlsv2\.ism)?/[^/]+\.m3u8!$1.ism/$1.m3u8!;
-					}
+					# for 320k audio (tv/radio) and 96k audio (radio)
+					$mobile_conn->{href} =~ s!([^/]+)\.ism(?:\.hlsv2\.ism)?/[^/]+\.m3u8!$1.ism/$1.m3u8!;
 					my ( $min_bitrate, $max_bitrate );
 					if ( $prefix eq "hvf" ) {
 						$max_bitrate = 6500;
@@ -7040,7 +7037,7 @@ sub get {
 	# look for higher-quality audio for hls modes
 	my $audio_file;	
 	my $audio_raw;	
-	my $hq_audio = $prog->{type} eq "tv" && $prog->{mode} =~ /hls/ && ! $opt->{nohqaudio};
+	my $hq_audio = $prog->{type} eq "tv" && $prog->{mode} =~ /hls/ && $opt->{hlshqaudio};
 	if ( $hq_audio ) {
 		main::logger "INFO: Attempting to download higher-quality audio for '$prog->{mode}' mode\n" if $opt->{verbose};
 		my $audio_prefix = "$prog->{fileprefix}.hqa";
@@ -7089,6 +7086,9 @@ sub get {
 		}
 		if ( $opt->{verbose} && ! -f $audio_file ) {
 			main::logger "WARNING: Could not record higher-quality audio for '$prog->{mode}' mode - using default audio\n";
+		}
+		if ( -f $audio_file ) {
+			main::logger "WARNING: Output file may require editing to sync audio and video\n";
 		}
 	}
 	if ( $opt->{raw} ) {


### PR DESCRIPTION
This change adds a --hls-hq-audio flag to opt in to using higher-
quality audio with "hls" TV modes. It is no longer used by default and
the --no-hq-audio option is now ignored. Warning is emitted to alert
users that editing may be necessary to sync audio and video.

I'm proposing this change because I have found a number of programmes have small audio/video sync problems when higher quality audio is added. I think it would be better to let users decide if they want to make the additional audio download and take the risk that the sync may need adjustment.