### PR TITLE
Detect unknown programme versions when --version includes "default"

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -3202,15 +3202,15 @@ sub generate_version_list {
 
 	# Default Order with which to search for programme versions (can be overridden by --versionlist option)
 	my @version_search_order = default_version_list();
+	for my $key ( keys %{$prog->{verpids}} ) {
+		next if $key =~ /(audiodescribed|signed)/;
+		$key =~ s/\s+.*$//;
+		if ( ! grep /^${key}$/i, @version_search_order ) {
+			push @version_search_order, lc($key);
+		}
+	}
 	if ( $opt->{versionlist} ) {
 		@version_search_order = map { /^default$/i ? @version_search_order : $_ } split /,/, $opt->{versionlist};
-	} else {
-		for my $key ( keys %{$prog->{verpids}} ) {
-			next if $key =~ /(audiodescribed|signed)/;
-			if ( ! grep /^${key}$/i, @version_search_order ) {
-				push @version_search_order, lc($key);
-			}
-		}
 	}
 
 	# check here for no matching verpids for specified version search list???


### PR DESCRIPTION
When --version option value includes "default", previously-unknown
versions are excluded from the list of possible versions to use for
downloading a programme. This change prevents that exclusion.

Example: 

https://www.bbc.co.uk/iplayer/episode/b03x1bs0/permission-impossible-britains-planners-episode-4

Programme only supplied a "pre-watershed" version that was previously unknown to get_iplayer.