### PR TITLE
Remove nulls from raw TTML subtitles

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -6687,6 +6687,7 @@ sub ttml_to_srt {
 	$columns = 37;
 	$huge = 'overflow';
 
+	$ttml =~ tr/\x00//d;
 	my $dom;
 	eval { $dom = XML::LibXML->load_xml(string => $ttml); };
 	if ( $@ ) {


### PR DESCRIPTION
This should help prevent at least some XML::LibXML parsing errors due
to corrupted subtitles.