### PR TITLE
don't print search terms error message with --refresh

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -856,7 +856,7 @@ sub find_matches {
 	}
 
 	unless ( @search_args ) {
-		if ( grep(/^(exclude|category|excludecategory|channel|excludechannel|availablesince|expiresbefore|since|before|list|tree|fields|future|long)$/, keys %{$opt}) || ( $opt->{type} && ! $opt->{refresh} ) ) {
+		if ( ! $opt->{refresh} && grep(/^(exclude|category|excludecategory|channel|excludechannel|availablesince|expiresbefore|since|before|list|tree|fields|future|long|type)$/, keys %{$opt}) ) {
 			# force to stderr for web pvr
 			print STDERR "ERROR: Search term(s) required. To list all programmes, use \".*\" (incl. quotes)\n";
 		}


### PR DESCRIPTION
The search terms error message is produced seemingly incorrectly if preferences has any of `exclude|category|excludecategory|channel|excludechannel|availablesince|expiresbefore|since|before|list|tree|fields|future|long`. In this case, the grep function matches even when using `--type` with `--refresh`. Assuming the intention of the previous commit was not to show a search error when refreshing, the current behaviour is unexpected.

I've tested this fix using `get_iplayer --refresh --since 8` (emulating the preference stored for PVR, not intending to search) on the following platforms:
- a FreeBSD 10.3-STABLE jail on a FreeNAS 9.10 host running all the latest get_iplayer dependencies (pkg install get_iplayer && pkg update) and contribute branch of get_iplayer installed in place of the outdated FreeBSD-packaged version.
- Windows 8.1 x64 with get_iplayer installed using the chocolatey package (3.09.0).
