### PR TITLE
Fix schedule refresh with limit at start of year

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -6057,6 +6057,7 @@ use LWP::UserAgent;
 use POSIX qw(ceil mkfifo strftime);
 use strict;
 use Time::Local;
+use Time::Piece;
 use URI;
 
 # Inherit from Programme class
@@ -6206,16 +6207,15 @@ sub get_links_schedule {
 		my $limit_days = $opt->{"refreshlimit".${prog_type}} || $opt->{"refreshlimit"};
 		$limit_days = 0 if $limit_days < 0;
 		$limit_days = 30 if $limit_days > 30;
-		$limit = $now - (ceil($limit_days / 7) * 7 * 86400) if $limit_days;
+		$limit = $now - ($limit_days * 86400) if $limit_days;
 		if ( $limit ) {
-			my $limit_time = $limit;
-			my $limit_year = (gmtime($limit_time))[5];
-			my $limit_week = strftime( "%W", gmtime($limit_time) );
-			while ( $limit_time < $then ) {
-				push @schedule_dates, sprintf("%04d/w%02d", $limit_year+1900, $limit_week+1);
-				$limit_time += $one_week;
-				$limit_year = (gmtime($limit_time))[5];
-				$limit_week = strftime( "%W", gmtime($limit_time) );
+			my $timepiece = gmtime( $now - (ceil($limit_days / 7) * 7 * 86400) );
+			my $iso8601_year_diff;
+			while ( $timepiece < $now ) {
+				$iso8601_year_diff = int($timepiece->mon == 12 && $timepiece->week == 1);
+				$iso8601_year_diff = -1 if $timepiece->mon == 1 && $timepiece->week > 51;
+				push @schedule_dates, sprintf("%04d/w%02d", $timepiece->year + $iso8601_year_diff, $timepiece->week);
+				$timepiece += $one_week;
 			}
 			push @schedule_dates, "this_week";
 		} else {


### PR DESCRIPTION
Revisiting my previous patch in this algorithm from a year ago, after seeing more unexpected behaviour. This PR should fix the following problems during schedule refresh with a limit:
- Missing earliest week within refresh limit
- Incorrectly requesting non-existent 2017/w53 instead of 2018/w01
- The week number calculated for some dates would lead to a schedule containing different dates
- Incorrect limit being used for availability check in `get_links_schedule_html_page`

Perl `strftime`'s definition for `%W` is `range 00 to 53, starting with the first Monday as the first day of week 01`. As can be seen by visiting the schedule pages, the BBC range is 01 to 53 also starting on Mondays, but sometimes the Monday of week 01 is in December the previous year. If I've correctly identified the BBC pattern, they're using ISO 8601 week numbers (week 01 contains January 4th and the first Thursday). This difference will cause a misalignment throughout 2019 and 2020 (if the other problems are fixed) where Perl week numbers will be offset by 1 from BBC week numbers.

I wrote a little test program to check that this PR gets the correct ISO 8601 week where previously it would be wrong:
```
2010-12-27: 2010/w53 -> 2010/w52
2010-12-28: 2010/w53 -> 2010/w52
2010-12-29: 2010/w53 -> 2010/w52
2010-12-30: 2010/w53 -> 2010/w52
2010-12-31: 2010/w53 -> 2010/w52
2011-01-01: 2011/w01 -> 2010/w52
2011-01-02: 2011/w01 -> 2010/w52
2011-01-03: 2011/w02 -> 2011/w01
2011-01-04: 2011/w02 -> 2011/w01
2011-01-05: 2011/w02 -> 2011/w01
2011-01-06: 2011/w02 -> 2011/w01
2011-01-07: 2011/w02 -> 2011/w01
2011-01-08: 2011/w02 -> 2011/w01
2011-01-09: 2011/w02 -> 2011/w01

2011-12-26: 2011/w53 -> 2011/w52
2011-12-27: 2011/w53 -> 2011/w52
2011-12-28: 2011/w53 -> 2011/w52
2011-12-29: 2011/w53 -> 2011/w52
2011-12-30: 2011/w53 -> 2011/w52
2011-12-31: 2011/w53 -> 2011/w52
2012-01-01: 2012/w01 -> 2011/w52
2012-01-02: 2012/w02 -> 2012/w01
2012-01-03: 2012/w02 -> 2012/w01
2012-01-04: 2012/w02 -> 2012/w01
2012-01-05: 2012/w02 -> 2012/w01
2012-01-06: 2012/w02 -> 2012/w01
2012-01-07: 2012/w02 -> 2012/w01
2012-01-08: 2012/w02 -> 2012/w01

2012-12-24: 2012/w53 -> 2012/w52
2012-12-25: 2012/w53 -> 2012/w52
2012-12-26: 2012/w53 -> 2012/w52
2012-12-27: 2012/w53 -> 2012/w52
2012-12-28: 2012/w53 -> 2012/w52
2012-12-29: 2012/w53 -> 2012/w52
2012-12-30: 2012/w53 -> 2012/w52
2012-12-31: 2012/w54 -> 2013/w01

2013-12-30: 2013/w53 -> 2014/w01
2013-12-31: 2013/w53 -> 2014/w01

2014-12-29: 2014/w53 -> 2015/w01
2014-12-30: 2014/w53 -> 2015/w01
2014-12-31: 2014/w53 -> 2015/w01

2016-01-01: 2016/w01 -> 2015/w53
2016-01-02: 2016/w01 -> 2015/w53
2016-01-03: 2016/w01 -> 2015/w53
2016-01-04: 2016/w02 -> 2016/w01
2016-01-05: 2016/w02 -> 2016/w01
2016-01-06: 2016/w02 -> 2016/w01
2016-01-07: 2016/w02 -> 2016/w01
2016-01-08: 2016/w02 -> 2016/w01
2016-01-09: 2016/w02 -> 2016/w01
2016-01-10: 2016/w02 -> 2016/w01

2016-12-26: 2016/w53 -> 2016/w52
2016-12-27: 2016/w53 -> 2016/w52
2016-12-28: 2016/w53 -> 2016/w52
2016-12-29: 2016/w53 -> 2016/w52
2016-12-30: 2016/w53 -> 2016/w52
2016-12-31: 2016/w53 -> 2016/w52
2017-01-01: 2017/w01 -> 2016/w52
2017-01-02: 2017/w02 -> 2017/w01
2017-01-03: 2017/w02 -> 2017/w01
2017-01-04: 2017/w02 -> 2017/w01
2017-01-05: 2017/w02 -> 2017/w01
2017-01-06: 2017/w02 -> 2017/w01
2017-01-07: 2017/w02 -> 2017/w01
2017-01-08: 2017/w02 -> 2017/w01

2017-12-25: 2017/w53 -> 2017/w52
2017-12-26: 2017/w53 -> 2017/w52
2017-12-27: 2017/w53 -> 2017/w52
2017-12-28: 2017/w53 -> 2017/w52
2017-12-29: 2017/w53 -> 2017/w52
2017-12-30: 2017/w53 -> 2017/w52
2017-12-31: 2017/w53 -> 2017/w52
2018-01-01: 2018/w02 -> 2018/w01
2018-01-02: 2018/w02 -> 2018/w01
2018-01-03: 2018/w02 -> 2018/w01
2018-01-04: 2018/w02 -> 2018/w01
2018-01-05: 2018/w02 -> 2018/w01
2018-01-06: 2018/w02 -> 2018/w01
2018-01-07: 2018/w02 -> 2018/w01

2018-12-24: 2018/w53 -> 2018/w52
2018-12-25: 2018/w53 -> 2018/w52
2018-12-26: 2018/w53 -> 2018/w52
2018-12-27: 2018/w53 -> 2018/w52
2018-12-28: 2018/w53 -> 2018/w52
2018-12-29: 2018/w53 -> 2018/w52
2018-12-30: 2018/w53 -> 2018/w52
2018-12-31: 2018/w54 -> 2019/w01

2019-12-30: 2019/w53 -> 2020/w01
2019-12-31: 2019/w53 -> 2020/w01

2021-01-01: 2021/w01 -> 2020/w53
2021-01-02: 2021/w01 -> 2020/w53
2021-01-03: 2021/w01 -> 2020/w53
2021-01-04: 2021/w02 -> 2021/w01
2021-01-05: 2021/w02 -> 2021/w01
2021-01-06: 2021/w02 -> 2021/w01
2021-01-07: 2021/w02 -> 2021/w01
2021-01-08: 2021/w02 -> 2021/w01
2021-01-09: 2021/w02 -> 2021/w01
2021-01-10: 2021/w02 -> 2021/w01
```

I've tested this patch today using `get_iplayer --refresh --refresh-limit 30` (confirming that `WARNING: Failed to download programme schedule ...` messages for 2017 week 53 no longer appear) on the following platforms:
- a FreeBSD 10.3-STABLE jail on a FreeNAS 9.10 host running all the latest get_iplayer dependencies (pkg install get_iplayer && pkg update) and contribute branch of get_iplayer installed in place of the outdated FreeBSD-packaged version.
- Windows 8.1 x64 with get_iplayer installed using the chocolatey package (3.09.0) and `Time::Piece` module copied from a separate 32bit Strawberry Perl installation to the bundled Perl.

Regarding Windows, this PR uses `Time::Piece` as an easy way to obtain portable ISO 8601 week numbering (first attempt used `strftime("%G/w%V",...)` which isn't portable). It appears that it's not included in the Strawberry Perl bundled with get_iplayer even though it's a core module. I don't know how easy it is to add, but if this is undesirable for whatever reason then I'm happy to investigate a dependency-free alternative.
