### PR TITLE
Fix unneeded schedule downloads with refresh limit

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -6054,7 +6054,7 @@ use IO::Seekable;
 use IO::Socket;
 use LWP::ConnCache;
 use LWP::UserAgent;
-use POSIX qw(ceil mkfifo strftime);
+use POSIX qw(mkfifo strftime);
 use strict;
 use Time::Local;
 use Time::Piece;
@@ -6209,9 +6209,11 @@ sub get_links_schedule {
 		$limit_days = 30 if $limit_days > 30;
 		$limit = $now - ($limit_days * 86400) if $limit_days;
 		if ( $limit ) {
-			my $timepiece = gmtime( $now - (ceil($limit_days / 7) * 7 * 86400) );
 			my $iso8601_year_diff;
-			while ( $timepiece < $now ) {
+			my $timepiece = gmtime($limit);
+			my $stop = $now - (((gmtime($now))[6] - 1) % 7) * 86400;
+			$timepiece -= (($timepiece->day_of_week - 1) % 7) * 86400;
+			while ( $timepiece < $stop ) {
 				$iso8601_year_diff = int($timepiece->mon == 12 && $timepiece->week == 1);
 				$iso8601_year_diff = -1 if $timepiece->mon == 1 && $timepiece->week > 51;
 				push @schedule_dates, sprintf("%04d/w%02d", $timepiece->year + $iso8601_year_diff, $timepiece->week);


### PR DESCRIPTION
As mentioned [here](https://github.com/get-iplayer/get_iplayer/pull/348#issuecomment-356910218), when refresh limit is not a multiple of 7 days and depending on the current day, an unnecessary extra schedule page before the limit might be downloaded for each channel. Clamping to Mondays prevents this.

Tested on FreeBSD and Windows using `get_iplayer --refresh --refresh-limit 30` confirming that `2017/w50`, `2017/w51`, `2017/w52`, `2018/w01` and `this_week` schedules are downloaded and `2017/w49` are not.