### PR TITLE
Deal with empty lock file correctly

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -2275,7 +2275,7 @@ sub lockfile {
 		close LOCKFILE;
 
 		# If the process is still running and the lockfile is newer than $stale_time seconds
-		if ( kill(0,$lines[0]) > 0 && $now < ( stat($lockfile)->mtime + $stale_time ) ) {
+		if ( scalar @lines > 0 && kill(0,$lines[0]) > 0 && $now < ( stat($lockfile)->mtime + $stale_time ) ) {
 				main::logger "ERROR: Quitting - process is already running ($lockfile)\n";
 				# redefine cleanup sub so that it doesn't delete $lockfile
 				$lockfile = '';


### PR DESCRIPTION
Lock files are sometimes zero length (eg. from a disk-full
condition).  Check for this (zero lines read) and skip
trying to test for existence of a previous process if this is the
case.

It might be better to take a real lock out on the file rather than relying on process identification.  Then the OS will automatically remove the lock when the process exists.  If you can't get a lock, there is
an old process still running.