### PR TITLE
(bugfix): Fix missing thumbnails for certain newer episodes/shows

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -5123,13 +5123,15 @@ sub parse_title {
 	$prog->{episodenum} ||= $episodenum;
 }
 
+# determine the thumbnail extension by querying playlist.json
+# some programmes are now using .png thumbnails
 sub get_thumbnail_ext {
 	my $prog = shift;
 	my $image_pid = shift;
 	my $ua = shift;
 	my $pid = $prog->{pid};
 
-	main::logger "DEBUG:: Using pid '$pid' and image pid '$image_pid' and ua '$ua'\n";
+	main::logger "DEBUG: Attempting to determine thumbnail extension using pid '$pid' and image pid '$image_pid'\n" if $opt->{debug};
 
 	my $url = "https://www.bbc.co.uk/programmes/$pid/playlist.json";
 	my $json = main::request_url_retry($ua, $url, 3, '', '');
@@ -5139,9 +5141,17 @@ sub get_thumbnail_ext {
 			my $holding_image = $dec->{holdingImage};
 			my $holding_image_filename = (split "/", $holding_image)[6];
 			my $holding_image_ext = (split /(\.)/, $holding_image_filename)[2];
-			main::logger "DEBUG:: Found extension '$holding_image_ext'\n";
+			main::logger "DEBUG: Found thumbnail extension '$holding_image_ext'\n" if $opt->{debug};
 			return $holding_image_ext;
+		} else {
+			main::logger "WARNING: Could not parse playlist metadata from $url\n";
+			main::logger "WARNING: Could not determine thumbnail extension. Falling back to '.jpg'\n";
+			return "jpg";
 		}
+	} else {
+		main::logger "WARNING: Could not download playlist metadata from $url\n";
+		main::logger "WARNING: Could not determine thumbnail extension. Falling back to '.jpg'\n";
+		return "jpg";
 	}
 }
 

--- a/get_iplayer
+++ b/get_iplayer
@@ -5123,6 +5123,28 @@ sub parse_title {
 	$prog->{episodenum} ||= $episodenum;
 }
 
+sub get_thumbnail_ext {
+	my $prog = shift;
+	my $image_pid = shift;
+	my $ua = shift;
+	my $pid = $prog->{pid};
+
+	main::logger "DEBUG:: Using pid '$pid' and image pid '$image_pid' and ua '$ua'\n";
+
+	my $url = "https://www.bbc.co.uk/programmes/$pid/playlist.json";
+	my $json = main::request_url_retry($ua, $url, 3, '', '');
+	if ( $json ) {
+		my $dec = eval { decode_json($json) };
+		if ( ! $@ ) {
+			my $holding_image = $dec->{holdingImage};
+			my $holding_image_filename = (split "/", $holding_image)[6];
+			my $holding_image_ext = (split /(\.)/, $holding_image_filename)[2];
+			main::logger "DEBUG:: Found extension '$holding_image_ext'\n";
+			return $holding_image_ext;
+		}
+	}
+}
+
 # get full episode metadata given pid and ua. Uses two different urls to get data
 sub get_metadata {
 	my $prog = shift;
@@ -5162,7 +5184,8 @@ sub get_metadata {
 					}
 				}
 				my $recipe = $prog->thumb_url_recipe();
-				$thumbnail = "https://ichef.bbci.co.uk/images/ic/${recipe}/${image_pid}.jpg";
+				my $thumbnail_ext = $prog->get_thumbnail_ext($image_pid, $ua);
+				$thumbnail = "https://ichef.bbci.co.uk/images/ic/${recipe}/${image_pid}.${thumbnail_ext}";
 				# /programmes page
 				$web = "https://www.bbc.co.uk/programmes/$pid";
 				# player page


### PR DESCRIPTION
Some newer episodes use `.png` thumbnails, and in these cases there is no `.jpg` thumbnail available.
This PR adds support for querying `playlist.json` to determine the thumbnail extension.

Examples:
`Boy Girl Dog Cat Mouse Cheese (m0009xgc)`
- Season 1: `.jpg`
- Season 2
  - Episodes 1-4: `.jpg`
  - Episodes 5+ `.png`
 
---


Programs in this series using `.png` (as of 2022)
<details closed>

```
Boy Girl Dog Cat Mouse Cheese - 5. Gametime, Go!, CBBC, m00134dj
Boy Girl Dog Cat Mouse Cheese - 6. Junked, CBBC, m0013c8h
Boy Girl Dog Cat Mouse Cheese - 7. Go Fetch, CBBC, m0013cc0
Boy Girl Dog Cat Mouse Cheese - 8. Tricked Out, CBBC, m0013ccv
Boy Girl Dog Cat Mouse Cheese - 9. The Room Mate, CBBC, m0013cdr
Boy Girl Dog Cat Mouse Cheese - 10. Chili Overload, CBBC, m0013cgm
Boy Girl Dog Cat Mouse Cheese - 11. X Marks the Spot, CBBC, m0013mcp
Boy Girl Dog Cat Mouse Cheese - 12. Lights! Camera! Action!, CBBC, m0013mfb
Boy Girl Dog Cat Mouse Cheese - 13. Dog Days, CBBC, m0013mgl
Boy Girl Dog Cat Mouse Cheese - 14. Narwhal Day, CBBC, m0013mhl
Boy Girl Dog Cat Mouse Cheese - 15. Bobblehead Heads, CBBC, m0013mjl
Boy Girl Dog Cat Mouse Cheese - 16. Mouse Steps, CBBC, m0013vb6
Boy Girl Dog Cat Mouse Cheese - 17. Gramps' Gauntlet of Greatness, CBBC, m0013vcy
Boy Girl Dog Cat Mouse Cheese - 18. Who Let the Weredogs Out, CBBC, m0013vbz
Boy Girl Dog Cat Mouse Cheese - 19. Staycation, CBBC, m0013vf6
Boy Girl Dog Cat Mouse Cheese - 20. The Swapper, CBBC, m0013vmn
Boy Girl Dog Cat Mouse Cheese - 21. Nothing but the Truth, CBBC, m00142ff
Boy Girl Dog Cat Mouse Cheese - 22. Gramps Date, CBBC, m00142fz
Boy Girl Dog Cat Mouse Cheese - 23. Grin and Parrot, CBBC, m00142j7
Boy Girl Dog Cat Mouse Cheese - 24. Future Proof, CBBC, m00142jl
Boy Girl Dog Cat Mouse Cheese - 25. For the Birds, CBBC, m00142jx
```

</details>
