### PR TITLE
Clarify message when programme not available

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -3784,7 +3784,7 @@ sub download_retry_loop {
 					main::logger "INFO: Available qualities: $available_qualities\n"
 				} else {
 					main::logger "INFO: No other recording quality is available\n";
-					main::logger "INFO: The programme may no longer be available - check the iPlayer or Sounds site\n";
+					main::logger "INFO: The programme may no longer, or may not yet, be available - check the iPlayer or Sounds site\n";
 					main::logger "INFO: The programme may only be available in an unsupported format (e.g., Flash) - check the iPlayer or Sounds site\n";
 					main::logger "INFO: If you use a VPN/VPS/Smart DNS/web proxy, it may have been blocked\n";
 				}
@@ -5460,7 +5460,7 @@ sub get_metadata {
 		} elsif ( $prog->{unavailable}->{$version} ) {
 			main::logger "WARNING: The BBC lists this programme as unavailable - check the iPlayer or Sounds site.\n";
 		} else {
-			main::logger "WARNING: The programme may no longer be available - check the iPlayer or Sounds site.\n";
+			main::logger "WARNING: The programme may no longer, or may not yet, be available - check the iPlayer or Sounds site.\n";
 			main::logger "WARNING: The programme may only be available in an unsupported format (e.g., Flash) - check the iPlayer or Sounds site.\n";
 			main::logger "WARNING: If you use a VPN/VPS/Smart DNS/web proxy, it may have been blocked.\n";
 		}


### PR DESCRIPTION
The message can also appear when trying to download a programme which has *never* been on iPlayer, so the wording "no longer available" is not correct.

Actually, my new suggested wording is a bit long-winded. Maybe it would be better to change to just "The programme may not be available" etc.