### PR TITLE
Remove national BBC One HD from programme schedule indexing

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -6956,7 +6956,6 @@ sub channels_schedule {
 		'national' => {
 			'p00fzl6b' => 'BBC Four', # bbcfour/programmes/schedules
 			'p00fzl6g' => 'BBC News', # bbcnews/programmes/schedules
-			'p00fzl6n' => 'BBC One', # bbcone/programmes/schedules/hd
 			'p00fzl73' => 'BBC Parliament', # bbcparliament/programmes/schedules
 			'p00fzl95' => 'BBC Three', # bbcthree/programmes/schedules
 			'p015pksy' => 'BBC Two', # bbctwo/programmes/schedules/hd


### PR DESCRIPTION
Possible fix for #471. I'm not sure if this is the optimum fix but it certainly stops the error message. I said in that issue that national BBC One listings had been unavailable for a few weeks - I see now it's actually only one week. It might be worth waiting a while to see if the lack of listings is permanent or just a temporary blip.

Closes #471