### PR TITLE
Remove original subtitle file if it has been embedded into the file

### DIFF
--- a/get_iplayer
+++ b/get_iplayer
@@ -6939,6 +6939,9 @@ sub postproc {
 
 	if ( (! $return) && -f $prog->{filepart} && stat($prog->{filepart})->size > $min_download_size ) {
 		unlink( $audio_file, $video_file );
+		if ( $opt->{subsembed} && -f $prog->{subsfile} ) {
+			unlink( $prog->{subsfile} );
+		}
 	} else {
 		# remove the failed converted file
 		unlink $prog->{filepart};


### PR DESCRIPTION
I'm not sure if this counts as an "enhancement"; I won't be offended if you close it.

But as someone who always uses --subs-embed, it has always bothered me that the original .srt file stuck around. This fixes that if that option is enabled.